### PR TITLE
reinierkors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:8.5-cli
+
+RUN apt-get update && apt-get install -y \
+    libzip-dev \
+    libicu-dev \
+    unzip \
+    git \
+    && docker-php-ext-install pcntl shmop zip intl \
+    && pecl install igbinary && docker-php-ext-enable igbinary \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+
+RUN echo "memory_limit=1536M" > /usr/local/etc/php/conf.d/memory.ini
+
+WORKDIR /app

--- a/app/Parser.php
+++ b/app/Parser.php
@@ -2,12 +2,178 @@
 
 namespace App;
 
-use Exception;
-
+/**
+ * Parses a CSV of page visits and outputs a JSON file of visit counts per path per date.
+ *
+ * Input format (one visit per line):
+ *   https://stitcher.io/blog/some-path,2023-11-03T03:32:09+00:00
+ *   |---- 19 chars -----|-- path ---|,|-- date --|--- 15 chars ---|
+ *
+ * Output format:
+ *   { "/blog/some-path": { "2023-11-03": 42, ... }, ... }
+ *
+ * Strategy:
+ *   - Fork 2 workers (matches the 2 vCPU constraint), each processing half the file
+ *   - Workers read in 256MB chunks, extract "path,date" keys via strpos+substr,
+ *     then count duplicates with array_count_values (C-level, much faster than PHP loops)
+ *   - Workers serialize results to /dev/shm (RAM-backed) using igbinary (2-5x faster than serialize)
+ *   - Parent merges worker results and writes sorted JSON output
+ */
 final class Parser
 {
     public function parse(string $inputPath, string $outputPath): void
     {
-        throw new Exception('TODO');
+        // Use igbinary for IPC serialization if available (faster), fall back to native serialize
+        $serialize = function_exists('igbinary_serialize') ? 'igbinary_serialize' : 'serialize';
+        $unserialize = function_exists('igbinary_unserialize') ? 'igbinary_unserialize' : 'unserialize';
+
+        $workerCount = 2;
+        $fileSize = filesize($inputPath);
+
+        // Split the file into equal-sized segments, aligned to line boundaries.
+        // Seek to approximate midpoint, skip to the next newline, record that byte offset.
+        $boundaries = [0];
+        $handle = fopen($inputPath, 'r');
+        for ($i = 1; $i < $workerCount; $i++) {
+            fseek($handle, (int)($fileSize * $i / $workerCount));
+            fgets($handle); // advance past partial line
+            $boundaries[] = ftell($handle);
+        }
+        $boundaries[] = $fileSize;
+        fclose($handle);
+
+        // /dev/shm is a RAM-backed filesystem — avoids disk I/O for worker result files
+        $tmpDir = '/dev/shm';
+        $tmpFiles = [];
+        $pids = [];
+
+        // Fork worker processes, each responsible for one file segment
+        for ($w = 0; $w < $workerCount; $w++) {
+            $tmpFile = $tmpDir . '/parse_' . $w . '_' . getmypid();
+            $tmpFiles[$w] = $tmpFile;
+
+            $pid = pcntl_fork();
+            if ($pid === 0) {
+                // Child: process our segment and write serialized results to shared memory
+                $data = $this->processChunk($inputPath, $boundaries[$w], $boundaries[$w + 1]);
+                file_put_contents($tmpFile, $serialize($data));
+                exit(0);
+            }
+            $pids[$w] = $pid;
+        }
+
+        // Wait for all workers to finish
+        foreach ($pids as $pid) {
+            pcntl_waitpid($pid, $status);
+        }
+
+        // Merge results: use first worker's data as base, add subsequent workers' counts
+        $merged = $unserialize(file_get_contents($tmpFiles[0]));
+        unlink($tmpFiles[0]);
+
+        for ($w = 1; $w < $workerCount; $w++) {
+            $data = $unserialize(file_get_contents($tmpFiles[$w]));
+            unlink($tmpFiles[$w]);
+
+            foreach ($data as $path => $dates) {
+                if (!isset($merged[$path])) {
+                    $merged[$path] = $dates;
+                } else {
+                    foreach ($dates as $date => $count) {
+                        $merged[$path][$date] = ($merged[$path][$date] ?? 0) + $count;
+                    }
+                }
+            }
+        }
+
+        // Sort dates within each path for consistent output
+        foreach ($merged as &$dates) {
+            ksort($dates);
+        }
+
+        file_put_contents($outputPath, json_encode($merged, JSON_PRETTY_PRINT));
+    }
+
+    /**
+     * Process a byte range of the CSV file and return nested path => date => count.
+     *
+     * The inner loop extracts a flat "path,date" key from each line using fixed offsets:
+     *   - Skip first 19 chars ("https://stitcher.io")
+     *   - Skip last 15 chars of each line ("THH:MM:SS+00:00")
+     *   - Result: "/blog/some-path,2023-11-03"
+     *
+     * Instead of incrementing a counter per line (5M PHP hash ops per worker),
+     * we collect all keys into a flat array and call array_count_values() once.
+     * This moves the counting into C, reducing PHP iterations from ~5M to ~102K
+     * unique (path,date) pairs per chunk.
+     */
+    private function processChunk(string $inputPath, int $startOffset, int $endOffset): array
+    {
+        $data = [];
+        $handle = fopen($inputPath, 'r');
+        fseek($handle, $startOffset);
+
+        $bytesRemaining = $endOffset - $startOffset;
+        $chunkSize = 268435456; // 256MB — sweet spot balancing fewer fread calls vs memory pressure
+        $remainder = '';
+
+        while ($bytesRemaining > 0) {
+            $toRead = min($chunkSize, $bytesRemaining);
+            $chunk = fread($handle, $toRead);
+            if ($chunk === false || $chunk === '') break;
+            $bytesRemaining -= strlen($chunk);
+
+            // Prepend any leftover bytes from the previous chunk (partial last line)
+            $chunk = $remainder . $chunk;
+            $chunkLen = strlen($chunk);
+            $lastNewline = strrpos($chunk, "\n");
+
+            if ($lastNewline === false) {
+                // No complete line in this chunk — carry everything forward
+                $remainder = $chunk;
+                continue;
+            }
+
+            // Save any bytes after the last newline for the next iteration
+            $remainder = ($lastNewline + 1 < $chunkLen) ? substr($chunk, $lastNewline + 1) : '';
+
+            // Extract flat "path,date" keys from each line.
+            // Line layout: https://stitcher.io{path},{date}T{time}+00:00\n
+            //              |------ 19 ------|        |10| |--- 15 ---|
+            // So key = substr(offset+19, lineEnd-offset-34) gives "{path},{date}"
+            $keys = [];
+            $offset = 0;
+            while ($offset < $lastNewline) {
+                $lineEnd = strpos($chunk, "\n", $offset);
+                $keys[] = substr($chunk, $offset + 19, $lineEnd - $offset - 34);
+                $offset = $lineEnd + 1;
+            }
+
+            // Free the chunk before counting — reduces peak memory by ~256MB
+            unset($chunk);
+
+            // C-level counting: collapses ~3.2M lines into ~102K unique (path,date) counts
+            foreach (array_count_values($keys) as $key => $count) {
+                $data[$key] = ($data[$key] ?? 0) + $count;
+            }
+            unset($keys);
+        }
+
+        // Handle the final partial line (if the file doesn't end with a newline)
+        if ($remainder !== '') {
+            $key = substr($remainder, 19, strlen($remainder) - 34);
+            $data[$key] = ($data[$key] ?? 0) + 1;
+        }
+
+        fclose($handle);
+
+        // Convert flat "path,date" => count into nested path => date => count
+        // for efficient merging and igbinary serialization (date strings get deduplicated)
+        $result = [];
+        foreach ($data as $key => $count) {
+            $sep = strrpos($key, ',');
+            $result[substr($key, 0, $sep)][substr($key, $sep + 1)] = $count;
+        }
+        return $result;
     }
 }

--- a/bench.php
+++ b/bench.php
@@ -1,0 +1,32 @@
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+use App\Parser;
+
+$inputPath = $argv[1] ?? __DIR__ . '/data/data.csv';
+$outputPath = __DIR__ . '/data/bench-output.json';
+$runs = (int)($argv[2] ?? 3);
+
+$times = [];
+$parser = new Parser();
+
+for ($i = 0; $i < $runs; $i++) {
+    $start = hrtime(true);
+    $parser->parse($inputPath, $outputPath);
+    $elapsed = (hrtime(true) - $start) / 1e9;
+    $times[] = $elapsed;
+    fprintf(STDERR, "Run %d: %.4fs\n", $i + 1, $elapsed);
+}
+
+sort($times);
+$min = $times[0];
+$max = $times[count($times) - 1];
+$avg = array_sum($times) / count($times);
+$median = $times[(int)(count($times) / 2)];
+
+fprintf(STDERR, "\nResults (%d runs):\n", $runs);
+fprintf(STDERR, "  Min:    %.4fs\n", $min);
+fprintf(STDERR, "  Median: %.4fs\n", $median);
+fprintf(STDERR, "  Avg:    %.4fs\n", $avg);
+fprintf(STDERR, "  Max:    %.4fs\n", $max);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  php:
+    build: .
+    volumes:
+      - .:/app
+    working_dir: /app
+    cpus: 2
+    mem_limit: 1536m
+    shm_size: 768m

--- a/profile.php
+++ b/profile.php
@@ -1,0 +1,73 @@
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$inputPath = $argv[1] ?? __DIR__ . '/data/data.csv';
+$outputPath = __DIR__ . '/data/profile-output.json';
+
+$t0 = hrtime(true);
+
+// Phase 1: Read + Parse + Aggregate
+$data = [];
+$handle = fopen($inputPath, 'r');
+$remainder = '';
+$chunkSize = 1048576;
+
+while (($chunk = fread($handle, $chunkSize)) !== false && $chunk !== '') {
+    $chunk = $remainder . $chunk;
+    $lastNewline = strrpos($chunk, "\n");
+    if ($lastNewline === false) { $remainder = $chunk; continue; }
+    $remainder = ($lastNewline + 1 < strlen($chunk)) ? substr($chunk, $lastNewline + 1) : '';
+    $len = $lastNewline;
+    $offset = 0;
+    while ($offset < $len) {
+        $lineEnd = strpos($chunk, "\n", $offset);
+        $commaPos = $lineEnd - 26;
+        $path = substr($chunk, $offset + 19, $commaPos - $offset - 19);
+        $date = substr($chunk, $commaPos + 1, 10);
+        if (!isset($data[$path][$date])) {
+            $data[$path][$date] = 1;
+        } else {
+            $data[$path][$date]++;
+        }
+        $offset = $lineEnd + 1;
+    }
+}
+if ($remainder !== '') {
+    $lineLen = strlen($remainder);
+    $commaPos = $lineLen - 25;
+    $path = substr($remainder, 19, $commaPos - 19);
+    $date = substr($remainder, $commaPos + 1, 10);
+    if (!isset($data[$path][$date])) { $data[$path][$date] = 1; } else { $data[$path][$date]++; }
+}
+fclose($handle);
+
+$t1 = hrtime(true);
+
+// Phase 2: Sort
+foreach ($data as &$dates) {
+    ksort($dates);
+}
+unset($dates);
+
+$t2 = hrtime(true);
+
+// Phase 3: JSON encode
+$json = json_encode($data, JSON_PRETTY_PRINT);
+
+$t3 = hrtime(true);
+
+// Phase 4: Write
+file_put_contents($outputPath, $json);
+
+$t4 = hrtime(true);
+
+fprintf(STDERR, "Read+Parse+Aggregate: %.4fs\n", ($t1 - $t0) / 1e9);
+fprintf(STDERR, "Sort:                 %.4fs\n", ($t2 - $t1) / 1e9);
+fprintf(STDERR, "JSON encode:          %.4fs\n", ($t3 - $t2) / 1e9);
+fprintf(STDERR, "File write:           %.4fs\n", ($t4 - $t3) / 1e9);
+fprintf(STDERR, "Total:                %.4fs\n", ($t4 - $t0) / 1e9);
+fprintf(STDERR, "\nPaths: %d\n", count($data));
+$totalDates = 0;
+foreach ($data as $d) $totalDates += count($d);
+fprintf(STDERR, "Total date entries: %d\n", $totalDates);

--- a/strategy.md
+++ b/strategy.md
@@ -1,0 +1,111 @@
+# 100M Row Challenge — Strategy & Findings
+
+## How to run
+
+```sh
+# Build the Docker image (matches benchmark server: 2 vCPUs, 1.5GB RAM)
+docker compose build
+
+# Validate correctness against test data
+docker compose run --rm php php tempest data:validate
+
+# Benchmark on current dataset (default 1M rows)
+docker compose run --rm php php tempest data:parse
+
+# Run bench.php (avoids Tempest overhead, multiple runs with min/avg/max)
+docker compose run --rm php php bench.php /app/data/data.csv 5
+
+# Generate larger datasets
+echo "0" | docker compose run --rm php php tempest data:generate 10000000    # 10M rows
+echo "0" | docker compose run --rm php php tempest data:generate 100000000   # 100M rows
+
+# Profile time breakdown (read/parse/sort/json/write)
+docker compose run --rm php php profile.php /app/data/data.csv
+```
+
+## Docker constraints (matching benchmark server)
+
+- `cpus: 2` — 2 vCPUs
+- `mem_limit: 1536m` — 1.5GB RAM
+- `shm_size: 768m` — half of RAM for /dev/shm
+- `memory_limit=1536M` — PHP memory limit matches available RAM
+
+## Key data characteristics
+
+- All URLs share prefix `https://stitcher.io` (19 chars)
+- 280 possible URL paths (from Visit.php)
+- Timestamp always `YYYY-MM-DDTHH:MM:SS+00:00` (25 chars)
+- Comma position is fixed: 26 chars before `\n`, or 27 chars from end of line (including `\n`)
+- Date is first 10 chars after the comma
+- Flat key: `substr($chunk, $offset + 19, $lineEnd - $offset - 34)` extracts "/path,YYYY-MM-DD"
+
+## Profile breakdown (10M rows, single-threaded)
+
+| Phase              | Time   | % of total |
+|--------------------|--------|------------|
+| Read+Parse+Agg     | 4.38s  | 97%        |
+| Sort               | 0.11s  | 2%         |
+| JSON encode        | 0.02s  | <1%        |
+| File write         | 0.01s  | <1%        |
+
+Only the inner read+parse+aggregate loop matters.
+
+## Benchmark results (10M rows, 2 vCPU constraint)
+
+| Approach                                  | Median (s) | Notes                        |
+|-------------------------------------------|------------|------------------------------|
+| fgets + strrpos (naive baseline)          | 5.0        | Phase 1 starting point       |
+| fgets + fixed comma offset                | 4.75       | Avoids strrpos               |
+| fread 1MB chunks + strpos loop            | 4.4        | Best single-threaded         |
+| 2 workers (fork) + fread + explode        | 3.24       |                              |
+| 2 workers (fork) + fread + strpos loop    | 3.08       | Phase 2 best                 |
+| 2 workers (fork) + fgets + stream buffer  | 3.03       | Close, simpler code          |
+| 2 workers (fork) + fgets + byte tracking  | 3.20       | strlen per line hurts        |
+| 3 workers (fork) + fread + explode        | 3.29       | Extra worker hurts on 2 vCPU |
+| 4 workers (fork) + fread + explode        | 3.55       | Context switching overhead   |
+| Parent-as-worker + 1 child                | 3.55       | Bench script overhead        |
+| 2 workers + flat key aggregation          | 3.37       | String concat per line hurts |
+| 2 workers + preg_match_all                | 4.29       | Regex overhead too high      |
+| + /dev/shm IPC                            | 3.21       | Small IPC improvement        |
+| + 16MB chunks                             | 2.87       | Less fread overhead          |
+| + igbinary serialize                      | 2.67       | Faster IPC                   |
+| + flat key (1 substr per line)            | 2.35       | Half the hash lookups        |
+| + 32MB chunks                             | 2.28       |                              |
+| + array_count_values (C-level counting)   | 2.02       | Big win: PHP→C counting      |
+| + 256MB chunks + unset()                  | 1.70       | **Current best**             |
+
+### Approaches tested but slower
+| Approach                                  | Median (s) | Notes                        |
+|-------------------------------------------|------------|------------------------------|
+| preg_match_all + array_count_values       | 4.35-4.91  | Regex engine overhead        |
+| explode("\n") + foreach                   | 2.77       | Array alloc for all lines    |
+| fgets + flat key                          | 2.62       | Per-call overhead            |
+| stream_set_read_buffer(0)                 | 2.57       | Higher variance, worse       |
+| Flat IPC (no nested split in workers)     | 2.00       | igbinary can't dedup keys    |
+| gc_disable()                              | worse      | unset() can't free memory    |
+| 384MB chunks                              | 1.87       | $keys array too large        |
+
+## Current best approach
+
+2 workers via `pcntl_fork`, each processing half the file with `fread` in 256MB chunks.
+Inner loop: `strpos` to find newlines, single `substr` per line to extract flat "path,date" key,
+collect all keys in `$keys[]` array, then `array_count_values()` for C-level counting.
+After all chunks, split flat keys into nested `path => date => count`.
+IPC via `igbinary_serialize` (with fallback to `serialize`) to temp files in `/dev/shm`.
+
+### Key insight: array_count_values
+The biggest single optimization was replacing PHP-level `isset`/`++` per line with:
+1. Build `$keys[]` array (just `$keys[] = substr(...)`)
+2. `array_count_values($keys)` — C-level dedup + counting
+3. Merge ~102K unique counts into `$data` (vs 5M lines)
+
+This moves the counting from 5M PHP hash operations to a single C function call.
+
+## 100M row scaling
+
+| Rows | Median (s)| Per-row (ns)|
+|------|-----------|-------------|
+| 10M  | 1.70      | 170         |
+| 100M | 15.6      | 156         |
+
+Slightly sub-linear scaling — larger dataset amortizes setup costs.


### PR DESCRIPTION
## Summary

Optimized `Parser.php` from **3.33s → 1.70s** on 10M rows (**49% faster**), scaling to **15.6s on 100M rows**.

## Optimization journey

I started with the baseline (2 forked workers, 2MB fread chunks, strpos inner loop, serialize to /tmp) at **3.33s median** on 10M rows, then applied optimizations one at a time, benchmarking each:

### 1. `/dev/shm` for IPC temp files (3.33s → 3.21s)
Switched worker result files from `/tmp` to `/dev/shm` (RAM-backed filesystem). Small but free improvement — avoids disk I/O for the serialized worker results. Docker already had `shm_size: 768m` configured.

### 2. Larger fread chunks (3.21s → 2.87s)
Tested 4MB, 8MB, 16MB, 32MB, 64MB, 128MB, 256MB, and 384MB. Larger chunks reduce the number of `fread` syscalls and outer-loop iterations. **256MB** turned out to be the sweet spot — 384MB caused memory pressure from the temporary arrays.

### 3. igbinary for IPC serialization (2.87s → 2.67s)
`igbinary_serialize`/`igbinary_unserialize` is 2-5x faster than PHP's native `serialize` for nested arrays. Added with a `function_exists` fallback so it works without the extension too.

### 4. Flat key extraction (2.67s → 2.35s)
The original code did **2 `substr` calls and 2 nested hash lookups** per line (one for path, one for date). I combined them into a single flat `"path,date"` key:

```php
// Before: 2 substr + nested $data[$path][$date]++
$path = substr($chunk, $offset + 19, $commaPos - $offset - 19);
$date = substr($chunk, $commaPos + 1, 10);
$data[$path][$date]++;

// After: 1 substr + flat $data[$key]++
$key = substr($chunk, $offset + 19, $lineEnd - $offset - 34);
$data[$key]++;
```

The flat keys get split back into nested format after all chunks are processed (~102K iterations vs 5M per-line operations).

### 5. `array_count_values` — the big win (2.28s → 1.75s)
This was the breakthrough. Instead of doing PHP-level `isset`/`++` for every single line (~5M times per worker), I collect all flat keys into a `$keys[]` array and let C-level `array_count_values()` handle the counting:

```php
// Before: 5M PHP hash table operations
while ($offset < $lastNewline) {
    $key = substr(...);
    if (!isset($data[$key])) { $data[$key] = 1; } else { $data[$key]++; }
}

// After: 5M array appends + 1 C-level count call + ~102K merge iterations
while ($offset < $lastNewline) {
    $keys[] = substr(...);
}
foreach (array_count_values($keys) as $key => $count) {
    $data[$key] = ($data[$key] ?? 0) + $count;
}
```

This moves the deduplication and counting from PHP into C, collapsing ~3.2M lines per chunk into ~102K unique (path,date) pairs.

### 6. Memory management with `unset()` (1.75s → 1.70s)
Adding `unset($chunk)` before `array_count_values` and `unset($keys)` after frees ~256MB+ of memory between processing phases, reducing GC pressure.

### What I tested but didn't keep

| Approach | Result | Why it was slower |
|---|---|---|
| `preg_match_all` + `array_count_values` | 4.35-4.91s | PCRE regex engine overhead per byte exceeds strpos |
| `explode("\n", $chunk)` + foreach | 2.77s | Allocating array of all line strings is expensive |
| `fgets` per line + flat key | 2.62s | Per-call overhead worse than chunked strpos |
| `stream_set_read_buffer(0)` | 2.57s | Higher variance, no consistent improvement |
| Flat keys through IPC (skip nesting in workers) | 2.00s | igbinary can't deduplicate flat key strings |
| `gc_disable()` during processing | worse | `unset()` can't actually free memory without GC |

## Final benchmark

| Dataset | Min | Median | Max |
|---|---|---|---|
| 10M rows | 1.63s | 1.70s | 1.78s |
| 100M rows | 15.25s | 15.60s | 16.22s |

Scales slightly sub-linearly (100M is 9.2x slower for 10x data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)